### PR TITLE
Introduce `checkKeyComboSequenceIndex` and improve `bindEnvironment`

### DIFF
--- a/packages/keystrokes/readme.md
+++ b/packages/keystrokes/readme.md
@@ -80,6 +80,15 @@ using Keystrokes in. They are always case insensitive. The default behavior,
 intended for browser environments, is to use the value of the key property from
 keyboard events. You get get a list of valid [key names here][key-names].
 
+Key combos are made up of key names and operators. The operators separate the
+key combo into it's parts.
+
+| Operator | Name               | Description
+|----------|--------------------|-----------------------------------------------------
+| +        | Key Unit           | A group of key names. Can be pressed in any order.
+| >        | Group Separator    | Separates key units. Each key unit must be pressed and held in order.
+| ,        | Sequence Separator | Separates groups. Each group must be pressed and released in order. This will be familiar to vim users.
+
 ```js
 import { bindKey, bindKeyCombo } from '@rwh/keystrokes'
 

--- a/packages/keystrokes/src/key-combo-state.ts
+++ b/packages/keystrokes/src/key-combo-state.ts
@@ -20,11 +20,21 @@ export class KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps> {
 
     const s = keyComboStr.toLowerCase()
 
+    // operator
     let o = ''
+
+    // unit
     let k: string[] = []
+
+    // group
     let x: string[][] = [k]
+
+    // sequence
     let y: string[][][] = [x]
+
+    // combo
     const z: string[][][][] = [y]
+
     let isEscaped = false
 
     for (let i = 0; i < keyComboStr.length; i += 1) {
@@ -98,6 +108,11 @@ export class KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps> {
 
   get isPressed() {
     return !!this._isPressedWithFinalKey
+  }
+
+  get sequenceIndex() {
+    if (this.isPressed) return this._parsedKeyCombo.length
+    return this._sequenceIndex
   }
 
   private _normalizedKeyCombo: string


### PR DESCRIPTION
This PR introduces a new method, `checkKeyComboSequenceIndex`. This method takes a key combo and will return the index of the last currently active sequence in the combo. This will be useful for those who would like to create UI for showing what combos are in progress, and addresses #4. Thanks to @pilliq for suggesting the feature.

It also updates `bindEnvironment` to optionally take `onActive`, `onInactive`, `onKeyPressed`, `onKeyReleased`, `mapKeyComboEvent`, `selfReleasingKeys`, and `keyRemap` in an options object exactly like the Keystrokes constructor.

Lastly I've updated the readme to better explain how combo operators work.