### PR TITLE
Ensure event keys are properly lowercased

### DIFF
--- a/packages/keystrokes/package.json
+++ b/packages/keystrokes/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint ./src",
     "test": "vitest run",
     "build": "rm -rf dist/ && cp ../../readme.md readme.md && vite build",
-    "dev": "vite",
+    "dev": "vite build -w",
     "prepublishOnly": "pnpm run build"
   },
   "keywords": [

--- a/packages/keystrokes/src/keystrokes.ts
+++ b/packages/keystrokes/src/keystrokes.ts
@@ -316,27 +316,26 @@ export class Keystrokes<
 
   private _handleKeyPress(event: KeyEvent<OriginalEvent, KeyEventProps>) {
     ;(async () => {
-      if (!this._isActive) {
-        return
-      }
+      if (!this._isActive) return
 
-      let key = event.key.toLowerCase()
-      const remappedKey = this._keyRemap[key]
+      event = { ...event, key: event.key.toLowerCase() }
+
+      const remappedKey = this._keyRemap[event.key]
       if (remappedKey) {
-        key = remappedKey
+        event.key = remappedKey
       }
 
-      const keyPressHandlerStates = this._handlerStates[key]
+      const keyPressHandlerStates = this._handlerStates[event.key]
       if (keyPressHandlerStates) {
         for (const s of keyPressHandlerStates) {
           s.executePressed(event)
         }
       }
 
-      if (!this._activeKeySet.has(key)) {
-        this._activeKeySet.add(key)
+      if (!this._activeKeySet.has(event.key)) {
+        this._activeKeySet.add(event.key)
         this._activeKeyPresses.push({
-          key,
+          key: event.key,
           event,
         })
       }
@@ -353,19 +352,24 @@ export class Keystrokes<
 
   private _handleKeyRelease(event: KeyEvent<OriginalEvent, KeyEventProps>) {
     ;(async () => {
-      const key = event.key.toLowerCase()
+      event = { ...event, key: event.key.toLowerCase() }
 
-      const keyPressHandlerStates = this._handlerStates[key]
+      const remappedKey = this._keyRemap[event.key]
+      if (remappedKey) {
+        event.key = remappedKey
+      }
+
+      const keyPressHandlerStates = this._handlerStates[event.key]
       if (keyPressHandlerStates) {
         for (const s of keyPressHandlerStates) {
           s.executeReleased(event)
         }
       }
 
-      if (this._activeKeySet.has(key)) {
-        this._activeKeySet.delete(key)
+      if (this._activeKeySet.has(event.key)) {
+        this._activeKeySet.delete(event.key)
         for (let i = 0; i < this._activeKeyPresses.length; i += 1) {
-          if (this._activeKeyPresses[i].key === key) {
+          if (this._activeKeyPresses[i].key === event.key) {
             this._activeKeyPresses.splice(i, 1)
             i -= 1
             break

--- a/packages/keystrokes/src/tests/keystrokes.spec.ts
+++ b/packages/keystrokes/src/tests/keystrokes.spec.ts
@@ -437,6 +437,27 @@ describe('new Keystrokes(options)', () => {
       expect(event.finalKeyEvent).toBeTruthy()
       expect(event.finalKeyEvent.key).toBe('c')
     })
+
+    it('correctly handles combos with the shift key', async () => {
+      const keystrokes = createTestKeystrokes()
+
+      const handler = {
+        onPressed: vi.fn(),
+        onReleased: vi.fn(),
+      }
+      keystrokes.bindKeyCombo('shift>s', handler)
+
+      keystrokes.press({ key: 'shift' })
+      keystrokes.press({ key: 'S' })
+      await nextTick()
+
+      expect(handler.onPressed).toBeCalledTimes(1)
+
+      keystrokes.release({ key: 'S' })
+      await nextTick()
+
+      expect(handler.onReleased).toBeCalledTimes(1)
+    })
   })
 
   describe('#unbindKeyCombo(keyCombo, handler?)', () => {

--- a/packages/react-keystrokes/package.json
+++ b/packages/react-keystrokes/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint ./src",
     "test": "vitest run",
     "build": "rm -rf dist/ && cp ../../readme.md readme.md && vite build",
-    "dev": "vite",
+    "dev": "vite build -w",
     "prepublishOnly": "pnpm run build"
   },
   "keywords": [

--- a/packages/vue-keystrokes/package.json
+++ b/packages/vue-keystrokes/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint ./src",
     "test": "vitest run",
     "build": "rm -rf dist/ && cp ../../readme.md readme.md && vite build",
-    "dev": "vite",
+    "dev": "vite build -w",
     "prepublishOnly": "pnpm run build"
   },
   "keywords": [


### PR DESCRIPTION
When I introduced custom event objects I accidentally broke key comparison when activating a key combos handler when the key value was capitalized. This broke combos that contained shift. This PR fixes that issue by copying the event object and lowercasing the key value then using the event throughout the _handleKeyPress. Resolves another issue found by @NinjaNas in #6