### PR TITLE
Move to synchronous execution of combos

### DIFF
--- a/packages/keystrokes/src/browser-bindings.ts
+++ b/packages/keystrokes/src/browser-bindings.ts
@@ -1,8 +1,24 @@
-import {
-  BrowserKeyEventProps,
-  OnActiveEventBinder,
-  OnKeyEventBinder,
-} from './keystrokes'
+import { OnActiveEventBinder, OnKeyEventBinder } from './keystrokes'
+
+export type BrowserKeyEventProps = {
+  composedPath(): EventTarget[]
+  preventDefault(): void
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type BrowserKeyComboEventProps = {}
+
+export type MaybeBrowserKeyEventProps<OriginalEvent> =
+  OriginalEvent extends KeyboardEvent
+    ? BrowserKeyEventProps
+    : // eslint-disable-next-line @typescript-eslint/ban-types
+      {}
+
+export type MaybeBrowserKeyComboEventProps<OriginalEvent> =
+  OriginalEvent extends KeyboardEvent
+    ? BrowserKeyComboEventProps
+    : // eslint-disable-next-line @typescript-eslint/ban-types
+      {}
 
 // NOTE: These stubs are only used if the library is used in a non-browser
 // environment with default binders.
@@ -115,15 +131,14 @@ export const browserOnKeyPressedBinder: OnKeyEventBinder<
 > = (handler) => {
   try {
     const handlerWrapper = (e: KeyboardEvent) => {
-      const originalComposedPath = e.composedPath()
-
       addActiveKeyEvent(e)
       maybeHandleMacOSCommandKeyDown(e)
 
       return handler({
         key: e.key,
         originalEvent: e,
-        composedPath: () => originalComposedPath,
+        composedPath: () => e.composedPath(),
+        preventDefault: () => e.preventDefault(),
       })
     }
     getDoc().addEventListener('keydown', handlerWrapper)
@@ -137,8 +152,6 @@ export const browserOnKeyReleasedBinder: OnKeyEventBinder<
 > = (handler) => {
   try {
     const handlerWrapper = (e: KeyboardEvent) => {
-      const originalComposedPath = e.composedPath()
-
       removeActiveKeyEvent(e)
       maybeDispatchMacOSCommandKeyUp()
       if (shouldInterceptMacOSCommandKeyUp(e)) return
@@ -146,7 +159,8 @@ export const browserOnKeyReleasedBinder: OnKeyEventBinder<
       return handler({
         key: e.key,
         originalEvent: e,
-        composedPath: () => originalComposedPath,
+        composedPath: () => e.composedPath(),
+        preventDefault: () => e.preventDefault(),
       })
     }
     getDoc().addEventListener('keyup', handlerWrapper)

--- a/packages/keystrokes/src/tests/browser-bindings.spec.ts
+++ b/packages/keystrokes/src/tests/browser-bindings.spec.ts
@@ -5,7 +5,6 @@ import {
   browserOnKeyPressedBinder,
   browserOnKeyReleasedBinder,
 } from '../browser-bindings'
-import { execFile } from 'child_process'
 
 describe('browserOnActiveBinder(handler) -> void', () => {
   it('correctly binds the given handler to window focus', () => {

--- a/packages/keystrokes/src/tests/index.spec.ts
+++ b/packages/keystrokes/src/tests/index.spec.ts
@@ -6,7 +6,6 @@ import {
   getGlobalKeystrokes,
   unbindKey,
 } from '..'
-import { nextTick } from '../keystrokes'
 
 let press: (key: string) => void = () => {
   throw new Error('onKeyPressed not bound')
@@ -79,28 +78,14 @@ describe('exported globalKeystrokes methods', () => {
 
       press('a')
       press('a')
-
-      await nextTick()
-
       release('a')
-
       press('b')
       press('c')
-
-      await nextTick()
-
       release('c')
       release('b')
-
       press('d')
       press('d')
-
-      await nextTick()
-
       release('d')
-
-      await nextTick()
-      await nextTick()
 
       expect(handler1.onPressed).toBeCalledTimes(1)
       expect(handler1.onPressedWithRepeat).toBeCalledTimes(2)

--- a/packages/keystrokes/src/tests/keystrokes.spec.ts
+++ b/packages/keystrokes/src/tests/keystrokes.spec.ts
@@ -3,12 +3,11 @@ import {
   BrowserKeyComboEventProps,
   BrowserKeyEventProps,
   Keystrokes,
-  nextTick,
 } from '../keystrokes'
 import { KeyComboEvent, KeyEvent, createTestKeystrokes } from '..'
 
 describe('new Keystrokes(options)', () => {
-  it('will automatically release self-releasing keys', async () => {
+  it('will automatically release self-releasing keys', () => {
     const keystrokes = createTestKeystrokes({
       selfReleasingKeys: ['meta', 'z'],
     })
@@ -16,17 +15,16 @@ describe('new Keystrokes(options)', () => {
     expect(keystrokes.checkKeyCombo('meta > z')).toBe(false)
 
     keystrokes.press({ key: 'meta' })
-    await nextTick()
+
     expect(keystrokes.checkKey('meta')).toBe(true)
     expect(keystrokes.checkKeyCombo('meta > z')).toBe(false)
 
     keystrokes.press({ key: 'z' })
-    await nextTick()
+
     expect(keystrokes.checkKey('z')).toBe(true)
     expect(keystrokes.checkKeyCombo('meta > z')).toBe(true)
 
     keystrokes.release({ key: 'meta' })
-    await nextTick()
 
     expect(keystrokes.checkKey('z')).toBe(false)
     expect(keystrokes.checkKey('meta')).toBe(false)
@@ -281,7 +279,7 @@ describe('new Keystrokes(options)', () => {
   })
 
   describe('#bindKeyCombo(keyCombo, handler)', () => {
-    it('accepts a key combo and when that combo is satisfied the given handler is executed', async () => {
+    it('accepts a key combo and when that combo is satisfied the given handler is executed', () => {
       const keystrokes = createTestKeystrokes()
 
       const handler1 = {
@@ -299,28 +297,17 @@ describe('new Keystrokes(options)', () => {
 
       keystrokes.press({ key: 'a' })
       keystrokes.press({ key: 'a' })
-
-      await nextTick()
-
       keystrokes.release({ key: 'a' })
 
-      await nextTick()
-
       keystrokes.press({ key: 'b' })
       keystrokes.press({ key: 'b' })
       keystrokes.press({ key: 'd' })
       keystrokes.press({ key: 'd' })
       keystrokes.press({ key: 'c' })
       keystrokes.press({ key: 'c' })
-
-      await nextTick()
-
       keystrokes.release({ key: 'b' })
       keystrokes.release({ key: 'c' })
       keystrokes.release({ key: 'd' })
-
-      await nextTick()
-      await nextTick()
 
       expect(handler1.onPressed).toBeCalledTimes(1)
       expect(handler1.onPressedWithRepeat).toBeCalledTimes(2)
@@ -330,7 +317,7 @@ describe('new Keystrokes(options)', () => {
       expect(handler2.onReleased).toBeCalledTimes(1)
     })
 
-    it('will not trigger a key combo handler if the keys are pressed in the wrong order', async () => {
+    it('will not trigger a key combo handler if the keys are pressed in the wrong order', () => {
       const keystrokes = createTestKeystrokes()
 
       const handler1 = {
@@ -348,28 +335,16 @@ describe('new Keystrokes(options)', () => {
 
       keystrokes.press({ key: 'd' })
       keystrokes.press({ key: 'd' })
-
-      await nextTick()
-
       keystrokes.release({ key: 'd' })
 
       keystrokes.press({ key: 'b' })
       keystrokes.press({ key: 'c' })
-
-      await nextTick()
-
       keystrokes.release({ key: 'c' })
       keystrokes.release({ key: 'b' })
 
       keystrokes.press({ key: 'a' })
       keystrokes.press({ key: 'a' })
-
-      await nextTick()
-
       keystrokes.release({ key: 'a' })
-
-      await nextTick()
-      await nextTick()
 
       expect(handler1.onPressed).toBeCalledTimes(0)
       expect(handler1.onPressedWithRepeat).toBeCalledTimes(0)
@@ -379,7 +354,7 @@ describe('new Keystrokes(options)', () => {
       expect(handler2.onReleased).toBeCalledTimes(0)
     })
 
-    it('provides all key events invoked while the combo was being satisfied', async () => {
+    it('provides all key events invoked while the combo was being satisfied', () => {
       const keystrokes = createTestKeystrokes()
 
       const handler = {
@@ -390,25 +365,13 @@ describe('new Keystrokes(options)', () => {
       keystrokes.bindKeyCombo('a,b>c+d', handler)
 
       keystrokes.press({ key: 'a' })
-
-      await nextTick()
-
       keystrokes.release({ key: 'a' })
-
-      await nextTick()
-
       keystrokes.press({ key: 'b' })
       keystrokes.press({ key: 'd' })
       keystrokes.press({ key: 'c' })
-
-      await nextTick()
-
       keystrokes.release({ key: 'b' })
       keystrokes.release({ key: 'c' })
       keystrokes.release({ key: 'd' })
-
-      await nextTick()
-      await nextTick()
 
       const event = handler.onPressed.mock.calls[0][0] as KeyComboEvent<
         KeyboardEvent,
@@ -424,7 +387,7 @@ describe('new Keystrokes(options)', () => {
       expect(event.keyEvents.some((e) => e.key === 'd')).toBe(true)
     })
 
-    it('provides the final key event that invoked in order to satisfy the combo', async () => {
+    it('provides the final key event that invoked in order to satisfy the combo', () => {
       const keystrokes = createTestKeystrokes()
 
       const handler = {
@@ -435,25 +398,13 @@ describe('new Keystrokes(options)', () => {
       keystrokes.bindKeyCombo('a,b>c+d', handler)
 
       keystrokes.press({ key: 'a' })
-
-      await nextTick()
-
       keystrokes.release({ key: 'a' })
-
-      await nextTick()
-
       keystrokes.press({ key: 'b' })
       keystrokes.press({ key: 'd' })
       keystrokes.press({ key: 'c' })
-
-      await nextTick()
-
       keystrokes.release({ key: 'b' })
       keystrokes.release({ key: 'c' })
       keystrokes.release({ key: 'd' })
-
-      await nextTick()
-      await nextTick()
 
       const event = handler.onPressed.mock.calls[0][0] as KeyComboEvent<
         KeyboardEvent,
@@ -465,7 +416,7 @@ describe('new Keystrokes(options)', () => {
       expect(event.finalKeyEvent.key).toBe('c')
     })
 
-    it('correctly handles combos with the shift key', async () => {
+    it('correctly handles combos with the shift key', () => {
       const keystrokes = createTestKeystrokes()
 
       const handler = {
@@ -476,19 +427,17 @@ describe('new Keystrokes(options)', () => {
 
       keystrokes.press({ key: 'shift' })
       keystrokes.press({ key: 'S' })
-      await nextTick()
 
       expect(handler.onPressed).toBeCalledTimes(1)
 
       keystrokes.release({ key: 'S' })
-      await nextTick()
 
       expect(handler.onReleased).toBeCalledTimes(1)
     })
   })
 
   describe('#unbindKeyCombo(keyCombo, handler?)', () => {
-    it('remove a handler for a given key combo', async () => {
+    it('remove a handler for a given key combo', () => {
       const keystrokes = createTestKeystrokes()
 
       const handler1 = vi.fn()
@@ -500,15 +449,9 @@ describe('new Keystrokes(options)', () => {
       keystrokes.press({ key: 'b' })
       keystrokes.press({ key: 'b' })
 
-      await nextTick()
-      await nextTick()
-
       keystrokes.unbindKeyCombo('a>b', handler2)
 
       keystrokes.press({ key: 'b' })
-
-      await nextTick()
-      await nextTick()
 
       expect(handler1).toBeCalledTimes(3)
       expect(handler2).toBeCalledTimes(2)

--- a/packages/react-keystrokes/src/tests/use-key-combo.spec.tsx
+++ b/packages/react-keystrokes/src/tests/use-key-combo.spec.tsx
@@ -58,8 +58,6 @@ describe('useKeyCombo(keyCombo) -> isPressed', () => {
 
     keystrokes.press({ key: 'a' })
     keystrokes.press({ key: 'b' })
-    await wait()
-
     keystrokes.release({ key: 'a' })
     keystrokes.release({ key: 'b' })
     await wait()

--- a/packages/react-keystrokes/src/tests/use-key.spec.tsx
+++ b/packages/react-keystrokes/src/tests/use-key.spec.tsx
@@ -56,8 +56,6 @@ describe('useKey(key) -> isPressed', () => {
     )
 
     keystrokes.press({ key: 'a' })
-    await wait()
-
     keystrokes.release({ key: 'a' })
     await wait()
 

--- a/packages/vue-keystrokes/src/tests/use-key-combo.spec.ts
+++ b/packages/vue-keystrokes/src/tests/use-key-combo.spec.ts
@@ -50,7 +50,6 @@ describe('useKeyCombo(keyCombo) -> isPressed', () => {
 
     keystrokes.press({ key: 'a' })
     keystrokes.press({ key: 'b' })
-
     await wait()
 
     expect(w.get('div').text()).toEqual('isPressed')
@@ -65,8 +64,6 @@ describe('useKeyCombo(keyCombo) -> isPressed', () => {
 
     keystrokes.press({ key: 'a' })
     keystrokes.press({ key: 'b' })
-    await wait()
-
     keystrokes.release({ key: 'a' })
     keystrokes.release({ key: 'b' })
     await wait()


### PR DESCRIPTION
In order to fix #19 as well as reduce the potential complexity of binders. After this change it will be possible to interact with the originalEvent within the same tick as the event emission.

This PR makes the execution of combos synchronous, and no longer batches updates. This will have a small performance impact, but after testing that seems to be a safe change for even complex binding setups.
