### PR TITLE
Fix MacOS Command Key Handling

### DIFF
--- a/packages/keystrokes/src/key-combo-state.ts
+++ b/packages/keystrokes/src/key-combo-state.ts
@@ -107,7 +107,7 @@ export class KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps> {
   }
 
   get isPressed() {
-    return !!this._isPressedWithFinalKey
+    return !!this._isPressedWithFinalUnit
   }
 
   get sequenceIndex() {
@@ -121,7 +121,7 @@ export class KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps> {
     KeyComboEvent<OriginalEvent, KeyEventProps, KeyComboEventProps>
   >
   private _lastActiveKeyPresses: KeyPress<OriginalEvent, KeyEventProps>[][]
-  private _isPressedWithFinalKey: KeyPress<OriginalEvent, KeyEventProps> | null
+  private _isPressedWithFinalUnit: Set<string> | null
   private _sequenceIndex: number
   private _keyComboEventMapper: KeyComboEventMapper<
     OriginalEvent,
@@ -145,7 +145,7 @@ export class KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps> {
     this._handlerState = new HandlerState(handler)
     this._keyComboEventMapper = keyComboEventMapper
     this._lastActiveKeyPresses = []
-    this._isPressedWithFinalKey = null
+    this._isPressedWithFinalUnit = null
     this._sequenceIndex = 0
   }
 
@@ -158,22 +158,18 @@ export class KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps> {
   }
 
   executePressed(event: KeyEvent<OriginalEvent, KeyEventProps>) {
-    if (this._isPressedWithFinalKey?.key !== event.key) {
-      return
-    }
+    if (!this._isPressedWithFinalUnit?.has(event.key)) return
     this._handlerState.executePressed(
-      this._wrapEvent(this._lastActiveKeyPresses, this._isPressedWithFinalKey),
+      this._wrapEvent(this._lastActiveKeyPresses, { key: event.key, event }),
     )
   }
 
   executeReleased(event: KeyEvent<OriginalEvent, KeyEventProps>) {
-    if (this._isPressedWithFinalKey?.key !== event.key) {
-      return
-    }
+    if (!this._isPressedWithFinalUnit?.has(event.key)) return
     this._handlerState.executeReleased(
-      this._wrapEvent(this._lastActiveKeyPresses, this._isPressedWithFinalKey),
+      this._wrapEvent(this._lastActiveKeyPresses, { key: event.key, event }),
     )
-    this._isPressedWithFinalKey = null
+    this._isPressedWithFinalUnit = null
   }
 
   updateState(activeKeys: KeyPress<OriginalEvent, KeyEventProps>[]) {
@@ -197,7 +193,7 @@ export class KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps> {
         }
         if (!foundKey) {
           if (this._handlerState.isEmpty) {
-            this._isPressedWithFinalKey = null
+            this._isPressedWithFinalUnit = null
           }
           return
         }
@@ -231,7 +227,7 @@ export class KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps> {
     }
 
     this._sequenceIndex = 0
-    this._isPressedWithFinalKey = activeKeys[activeKeys.length - 1]
+    this._isPressedWithFinalUnit = new Set(sequence[sequence.length - 1])
   }
 
   _wrapEvent(

--- a/packages/keystrokes/src/keystrokes.ts
+++ b/packages/keystrokes/src/keystrokes.ts
@@ -87,7 +87,7 @@ export class Keystrokes<
     KeyComboEventProps
   >[]
   private _activeKeyPresses: KeyPress<OriginalEvent, KeyEventProps>[]
-  private _activeKeySet: Set<string>
+  private _activeKeyMap: Map<string, KeyPress<OriginalEvent, KeyEventProps>>
 
   private _watchedKeyComboStates: Record<
     string,
@@ -115,7 +115,7 @@ export class Keystrokes<
     this._keyComboStates = {}
     this._keyComboStatesArray = []
     this._activeKeyPresses = []
-    this._activeKeySet = new Set()
+    this._activeKeyMap = new Map()
 
     this._watchedKeyComboStates = {}
 
@@ -211,7 +211,7 @@ export class Keystrokes<
   }
 
   checkKey(key: string) {
-    return this._activeKeySet.has(key.toLowerCase())
+    return this._activeKeyMap.has(key.toLowerCase())
   }
 
   checkKeyCombo(keyCombo: string) {
@@ -306,12 +306,16 @@ export class Keystrokes<
       }
     }
 
-    if (!this._activeKeySet.has(event.key)) {
-      this._activeKeySet.add(event.key)
-      this._activeKeyPresses.push({
+    const existingKeypress = this._activeKeyMap.get(event.key)
+    if (existingKeypress) {
+      existingKeypress.event = event
+    } else {
+      const keypress = {
         key: event.key,
         event,
-      })
+      }
+      this._activeKeyMap.set(event.key, keypress)
+      this._activeKeyPresses.push(keypress)
     }
 
     this._updateKeyComboStates()
@@ -336,8 +340,8 @@ export class Keystrokes<
       }
     }
 
-    if (this._activeKeySet.has(event.key)) {
-      this._activeKeySet.delete(event.key)
+    if (this._activeKeyMap.has(event.key)) {
+      this._activeKeyMap.delete(event.key)
       for (let i = 0; i < this._activeKeyPresses.length; i += 1) {
         if (this._activeKeyPresses[i].key === event.key) {
           this._activeKeyPresses.splice(i, 1)

--- a/packages/keystrokes/src/tests/browser-bindings.spec.ts
+++ b/packages/keystrokes/src/tests/browser-bindings.spec.ts
@@ -136,10 +136,10 @@ describe('browserOnKeyPressedBinder(handler) -> void', () => {
   })
 
   describe('/macOS Specific Behavior/', () => {
-    it('generates a synthetic keyup for the command key when any other key is released', () => {
+    it('will release all keys pressed once meta is released', () => {
       const addEventListenerStub = vi.fn()
-      const keyPressedhandlerStub = vi.fn()
-      const keyReleasehandlerStub = vi.fn()
+      const keyPressedHandlerStub = vi.fn()
+      const keyReleaseHandlerStub = vi.fn()
       const dispatchEventStub = vi.fn()
       vi.spyOn(document, 'addEventListener').mockImplementation(
         addEventListenerStub,
@@ -147,8 +147,8 @@ describe('browserOnKeyPressedBinder(handler) -> void', () => {
       vi.spyOn(document, 'dispatchEvent').mockImplementation(dispatchEventStub)
       vi.stubGlobal('navigator', { userAgent: 'mac' })
 
-      browserOnKeyPressedBinder(keyPressedhandlerStub)
-      browserOnKeyReleasedBinder(keyReleasehandlerStub)
+      browserOnKeyPressedBinder(keyPressedHandlerStub)
+      browserOnKeyReleasedBinder(keyReleaseHandlerStub)
 
       const keyPressedHandler = addEventListenerStub.mock.calls[0][1]
       const keyReleasedHandler = addEventListenerStub.mock.calls[1][1]
@@ -166,8 +166,8 @@ describe('browserOnKeyPressedBinder(handler) -> void', () => {
         cancelable: true,
       })
       const aKeyupEvent = new KeyboardEvent('keydown', {
-        key: 'a',
-        code: 'a',
+        key: 'Meta',
+        code: 'MetaRight',
         bubbles: true,
         cancelable: true,
       })
@@ -186,7 +186,7 @@ describe('browserOnKeyPressedBinder(handler) -> void', () => {
         'keyup',
         expect.any(Function),
       )
-      expect(keyPressedhandlerStub).nthCalledWith(
+      expect(keyPressedHandlerStub).nthCalledWith(
         1,
         expect.objectContaining({
           composedPath: expect.any(Function),
@@ -194,7 +194,7 @@ describe('browserOnKeyPressedBinder(handler) -> void', () => {
           originalEvent: metaKeydownEvent,
         }),
       )
-      expect(keyPressedhandlerStub).nthCalledWith(
+      expect(keyPressedHandlerStub).nthCalledWith(
         2,
         expect.objectContaining({
           composedPath: expect.any(Function),
@@ -202,11 +202,11 @@ describe('browserOnKeyPressedBinder(handler) -> void', () => {
           originalEvent: aKeydownEvent,
         }),
       )
-      expect(keyReleasehandlerStub).nthCalledWith(
+      expect(keyReleaseHandlerStub).nthCalledWith(
         1,
         expect.objectContaining({
           composedPath: expect.any(Function),
-          key: 'a',
+          key: 'Meta',
           originalEvent: aKeyupEvent,
         }),
       )
@@ -214,7 +214,7 @@ describe('browserOnKeyPressedBinder(handler) -> void', () => {
 
       const syntheticKeyboardEvent = dispatchEventStub.mock.calls[0][0]
       expect(syntheticKeyboardEvent.type).toBe('keyup')
-      expect(syntheticKeyboardEvent.key).toBe('Meta')
+      expect(syntheticKeyboardEvent.key).toBe('a')
 
       vi.unstubAllGlobals()
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1171,6 +1171,7 @@ packages:
   /esbuild@0.18.17:
     resolution: {integrity: sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==}
     engines: {node: '>=12'}
+    hasBin: true
     requiresBuild: true
     optionalDependencies:
       '@esbuild/android-arm': 0.18.17
@@ -1204,6 +1205,7 @@ packages:
 
   /eslint-config-prettier@8.10.0(eslint@8.46.0):
     resolution: {integrity: sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==}
+    hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
@@ -1795,6 +1797,7 @@ packages:
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
     dev: true
 
   /natural-compare-lite@1.4.0:
@@ -2072,6 +2075,7 @@ packages:
   /rollup@3.27.0:
     resolution: {integrity: sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -2238,6 +2242,7 @@ packages:
 
   /ts-node@10.9.1(@types/node@20.4.6)(typescript@5.1.6):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
@@ -2335,6 +2340,7 @@ packages:
   /vite@4.4.8(@types/node@20.4.6):
     resolution: {integrity: sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
@@ -2370,6 +2376,7 @@ packages:
   /vitest@0.34.1(happy-dom@10.6.3):
     resolution: {integrity: sha512-G1PzuBEq9A75XSU88yO5G4vPT20UovbC/2osB2KEuV/FisSIIsw7m5y2xMdB7RsAGHAfg2lPmp2qKr3KWliVlQ==}
     engines: {node: '>=v14.18.0'}
+    hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@vitest/browser': '*'


### PR DESCRIPTION
This PR fixes how the command key is managed on MacOS. There was an issue where keys pressed at the same time as meta would not fire keyup events. It also changes how event objects are managed so it is possible to easily interact with events to prevent default browser behaviours or call other methods on the event.