### PR TITLE
Reimplement KeyCombo#updateState

### DIFF
--- a/packages/keystrokes/src/handler-state.ts
+++ b/packages/keystrokes/src/handler-state.ts
@@ -42,18 +42,14 @@ export class HandlerState<Event> {
   }
 
   executePressed(event: Event) {
-    if (!this._isPressed) {
-      this._onPressed?.(event)
-    }
+    if (!this._isPressed) this._onPressed?.(event)
 
     this._isPressed = true
     this._onPressedWithRepeat?.(event)
   }
 
   executeReleased(event: Event) {
-    if (this._isPressed) {
-      this._onReleased?.(event)
-    }
+    if (this._isPressed) this._onReleased?.(event)
 
     this._isPressed = false
   }

--- a/packages/keystrokes/src/index.ts
+++ b/packages/keystrokes/src/index.ts
@@ -8,16 +8,13 @@ export type {
   KeystrokesOptions,
 } from './keystrokes'
 
-import { KeyEvent } from './handler-state'
-import { KeyComboState } from './key-combo-state'
 import {
-  Keystrokes,
-  KeystrokesOptions,
   MaybeBrowserKeyComboEventProps,
   MaybeBrowserKeyEventProps,
-} from './keystrokes'
-
-export { Keystrokes } from './keystrokes'
+} from './browser-bindings'
+import { KeyEvent } from './handler-state'
+import { KeyComboState } from './key-combo-state'
+import { Keystrokes, KeystrokesOptions } from './keystrokes'
 
 let globalKeystrokesOptions: KeystrokesOptions
 let globalKeystrokes: Keystrokes
@@ -27,9 +24,7 @@ export const setGlobalKeystrokes = (keystrokes?: Keystrokes) => {
 }
 
 export const getGlobalKeystrokes = () => {
-  if (!globalKeystrokes) {
-    setGlobalKeystrokes()
-  }
+  if (!globalKeystrokes) setGlobalKeystrokes()
   return globalKeystrokes
 }
 

--- a/packages/keystrokes/src/keystrokes.ts
+++ b/packages/keystrokes/src/keystrokes.ts
@@ -144,9 +144,7 @@ export class Keystrokes<
     key = key.toLowerCase()
 
     const handlerStates = this._handlerStates[key]
-    if (!handlerStates) {
-      return
-    }
+    if (!handlerStates) return
 
     if (handler) {
       for (let i = 0; i < handlerStates.length; i += 1) {
@@ -188,9 +186,7 @@ export class Keystrokes<
     keyCombo = KeyComboState.normalizeKeyCombo(keyCombo)
 
     const keyComboStates = this._keyComboStates[keyCombo]
-    if (!keyComboStates) {
-      return
-    }
+    if (!keyComboStates) return
 
     if (handler) {
       for (let i = 0; i < keyComboStates.length; i += 1) {
@@ -301,9 +297,7 @@ export class Keystrokes<
 
     const keyPressHandlerStates = this._handlerStates[event.key]
     if (keyPressHandlerStates) {
-      for (const s of keyPressHandlerStates) {
-        s.executePressed(event)
-      }
+      for (const s of keyPressHandlerStates) s.executePressed(event)
     }
 
     const existingKeypress = this._activeKeyMap.get(event.key)
@@ -320,9 +314,8 @@ export class Keystrokes<
 
     this._updateKeyComboStates()
 
-    for (const keyComboState of this._keyComboStatesArray) {
+    for (const keyComboState of this._keyComboStatesArray)
       keyComboState.executePressed(event)
-    }
   }
 
   private _handleKeyRelease(event: KeyEvent<OriginalEvent, KeyEventProps>) {
@@ -335,9 +328,7 @@ export class Keystrokes<
 
     const keyPressHandlerStates = this._handlerStates[event.key]
     if (keyPressHandlerStates) {
-      for (const s of keyPressHandlerStates) {
-        s.executeReleased(event)
-      }
+      for (const s of keyPressHandlerStates) s.executeReleased(event)
     }
 
     if (this._activeKeyMap.has(event.key)) {
@@ -354,23 +345,20 @@ export class Keystrokes<
     this._tryReleaseSelfReleasingKeys()
     this._updateKeyComboStates()
 
-    for (const keyComboState of this._keyComboStatesArray) {
+    for (const keyComboState of this._keyComboStatesArray)
       keyComboState.executeReleased(event)
-    }
   }
 
   private _updateKeyComboStates() {
-    for (const keyComboState of this._keyComboStatesArray) {
+    for (const keyComboState of this._keyComboStatesArray)
       keyComboState.updateState(this._activeKeyPresses)
-    }
   }
 
   private _tryReleaseSelfReleasingKeys() {
     for (const activeKey of this._activeKeyPresses) {
       for (const selfReleasingKey of this._selfReleasingKeys) {
-        if (activeKey.key === selfReleasingKey) {
+        if (activeKey.key === selfReleasingKey)
           this._handleKeyRelease(activeKey.event)
-        }
       }
     }
   }


### PR DESCRIPTION
The old implementation was originally designed to optimize for tick batching so that state per key combo was only calculated once per tick. while this was good for performance, it made it very difficult for users to interact with events (for example calling preventDefault).

The new implementation is a second take after learning from the limits and issues encountered from the first. The largest problem solved is sequence advancement happens once all keys are released. Random keys can no longer be pressed in-between sequences (this was never suppose) to work this way.

This closes #23 