### PR TITLE
Fix types and export react provider

### DIFF
--- a/packages/keystrokes/package.json
+++ b/packages/keystrokes/package.json
@@ -8,6 +8,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/keystrokes.js",
       "require": "./dist/keystrokes.umd.cjs"
     }

--- a/packages/react-keystrokes/package.json
+++ b/packages/react-keystrokes/package.json
@@ -8,6 +8,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/react-keystrokes.js",
       "require": "./dist/react-keystrokes.umd.cjs"
     }

--- a/packages/react-keystrokes/src/index.ts
+++ b/packages/react-keystrokes/src/index.ts
@@ -1,5 +1,5 @@
 export * from '@rwh/keystrokes'
 
-export { KeystrokesProvider } from './KeystrokesContext'
+export * from './KeystrokesContext'
 export { useKey } from './use-key'
 export { useKeyCombo } from './use-key-combo'

--- a/packages/react-keystrokes/src/index.ts
+++ b/packages/react-keystrokes/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@rwh/keystrokes'
 
+export { KeystrokesProvider } from './KeystrokesContext'
 export { useKey } from './use-key'
 export { useKeyCombo } from './use-key-combo'

--- a/packages/vue-keystrokes/package.json
+++ b/packages/vue-keystrokes/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/vue-keystrokes.js",
       "require": "./dist/vue-keystrokes.umd.cjs"
     }


### PR DESCRIPTION
- Exports the provider which is not currently possible to import
- Adds the types to the `exports` map in the package.json so that typescript is allowed to resolve the types (exports maps overwrites the "types" property in package.json)

Fixes error:

> There are types at .../node_modules/@rwh/react-keystrokes/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The @rwh/react-keystrokes' library may need to update its package.json or typings.