### PR TITLE
feat: expose preventDefault in react hook (#48)

### DIFF
--- a/packages/react-keystrokes/src/tests/use-key-combo.spec.tsx
+++ b/packages/react-keystrokes/src/tests/use-key-combo.spec.tsx
@@ -13,6 +13,11 @@ const TestComponent = () => {
   return <div>{isPressed ? 'isPressed' : 'isNotPressed'}</div>
 }
 
+const TestComponentWithPreventDefault = () => {
+  const isPressed = useKeyCombo('a+b', true)
+  return <div>{isPressed ? 'isPressed' : 'isNotPressed'}</div>
+}
+
 describe('useKeyCombo(keyCombo) -> isPressed', () => {
   it('initial state is unpressed', async () => {
     const keystrokes = createTestKeystrokes()
@@ -62,6 +67,34 @@ describe('useKeyCombo(keyCombo) -> isPressed', () => {
     keystrokes.release({ key: 'b' })
     await wait()
 
+    expect(root.findByType('div').children[0]).toEqual('isNotPressed')
+  })
+
+  it('prevents default when configured to', async () => {
+    const keystrokes = createTestKeystrokes()
+
+    const { root } = await act(() =>
+      create(
+        <KeystrokesProvider keystrokes={keystrokes}>
+          <TestComponentWithPreventDefault />
+        </KeystrokesProvider>,
+      ),
+    )
+
+    let defaultPrevented = false
+    const lastKeyEvent = {
+      key: 'b',
+      preventDefault() {
+        defaultPrevented = true
+      },
+    }
+    keystrokes.press({ key: 'a' })
+    keystrokes.press(lastKeyEvent)
+    keystrokes.release({ key: 'a' })
+    keystrokes.release(lastKeyEvent)
+    await wait()
+
+    expect(defaultPrevented).toEqual(true)
     expect(root.findByType('div').children[0]).toEqual('isNotPressed')
   })
 })

--- a/packages/react-keystrokes/src/tests/use-key.spec.tsx
+++ b/packages/react-keystrokes/src/tests/use-key.spec.tsx
@@ -13,6 +13,11 @@ const TestComponent = () => {
   return <div>{isPressed ? 'isPressed' : 'isNotPressed'}</div>
 }
 
+const TestComponentWithPreventDefault = () => {
+  const isPressed = useKey('a', true)
+  return <div>{isPressed ? 'isPressed' : 'isNotPressed'}</div>
+}
+
 describe('useKey(key) -> isPressed', () => {
   it('initial state is unpressed', async () => {
     const keystrokes = createTestKeystrokes()
@@ -59,6 +64,32 @@ describe('useKey(key) -> isPressed', () => {
     keystrokes.release({ key: 'a' })
     await wait()
 
+    expect(root.findByType('div').children[0]).toEqual('isNotPressed')
+  })
+
+  it('prevents default when configured to', async () => {
+    const keystrokes = createTestKeystrokes()
+
+    const { root } = await act(() =>
+      create(
+        <KeystrokesProvider keystrokes={keystrokes}>
+          <TestComponentWithPreventDefault />
+        </KeystrokesProvider>,
+      ),
+    )
+
+    let defaultPrevented = false
+    const keyEvent = {
+      key: 'a',
+      preventDefault() {
+        defaultPrevented = true
+      },
+    }
+    keystrokes.press(keyEvent)
+    keystrokes.release(keyEvent)
+    await wait()
+
+    expect(defaultPrevented).toEqual(true)
     expect(root.findByType('div').children[0]).toEqual('isNotPressed')
   })
 })

--- a/packages/react-keystrokes/src/use-key-combo.ts
+++ b/packages/react-keystrokes/src/use-key-combo.ts
@@ -1,14 +1,31 @@
 import { useState, useContext, useEffect } from 'react'
 import { KeystrokesContext } from './KeystrokesContext'
+import {
+  BrowserKeyComboEventProps,
+  BrowserKeyEventProps,
+  Handler,
+  KeyComboEvent,
+} from '@rwh/keystrokes'
 
-export const useKeyCombo = (keyCombo: string) => {
+export const useKeyCombo = (keyCombo: string, preventDefault?: boolean) => {
   const [isPressed, setIsPressed] = useState(false)
 
   const keystrokes = useContext(KeystrokesContext)()
 
   const updatePressedEffect = () => {
-    const handler = {
-      onPressed: () => setIsPressed(true),
+    const handler: Handler<
+      KeyComboEvent<
+        KeyboardEvent,
+        BrowserKeyEventProps,
+        BrowserKeyComboEventProps
+      >
+    > = {
+      onPressed: (e) => {
+        setIsPressed(true)
+        if (e.finalKeyEvent?.preventDefault && preventDefault === true) {
+          e.finalKeyEvent.preventDefault()
+        }
+      },
       onReleased: () => setIsPressed(false),
     }
     keystrokes.bindKeyCombo(keyCombo, handler)

--- a/packages/react-keystrokes/src/use-key.ts
+++ b/packages/react-keystrokes/src/use-key.ts
@@ -1,16 +1,23 @@
 import { useState, useContext, useEffect } from 'react'
 import { KeystrokesContext } from './KeystrokesContext'
+import type { BrowserKeyEventProps, Handler, KeyEvent } from '@rwh/keystrokes'
 
-export const useKey = (key: string) => {
+export const useKey = (key: string, preventDefault?: boolean) => {
   const [isPressed, setIsPressed] = useState(false)
 
   const keystrokes = useContext(KeystrokesContext)()
 
   const updatePressedEffect = () => {
-    const handler = {
-      onPressed: () => setIsPressed(true),
+    const handler: Handler<KeyEvent<KeyboardEvent, BrowserKeyEventProps>> = {
+      onPressed: (e: KeyEvent<KeyboardEvent, BrowserKeyEventProps>) => {
+        setIsPressed(true)
+        if (e.preventDefault && preventDefault === true) {
+          e.preventDefault()
+        }
+      },
       onReleased: () => setIsPressed(false),
     }
+
     keystrokes.bindKey(key, handler)
     return () => {
       keystrokes.unbindKey(key, handler)

--- a/packages/vue-keystrokes/src/tests/use-key.spec.ts
+++ b/packages/vue-keystrokes/src/tests/use-key.spec.ts
@@ -26,6 +26,15 @@ const TestComponent = defineComponent({
 `,
 })
 
+const TestComponentWithPreventDefault = defineComponent({
+  setup() {
+    return { isPressed: useKey('a', true) }
+  },
+  template: `
+    <div>{{isPressed ? 'isPressed' : 'isNotPressed'}}</div>
+`,
+})
+
 describe('useKey(key) -> isPressed', () => {
   it('initial state is unpressed', async () => {
     const keystrokes = createTestKeystrokes()
@@ -62,6 +71,28 @@ describe('useKey(key) -> isPressed', () => {
     keystrokes.release({ key: 'a' })
     await wait()
 
+    expect(w.get('div').text()).toEqual('isNotPressed')
+  })
+
+  it('prevents default when configured to', async () => {
+    const keystrokes = createTestKeystrokes()
+    const w = mount(ProviderComponent, {
+      slots: { default: TestComponentWithPreventDefault },
+      props: { keystrokes },
+    })
+
+    let defaultPrevented = false
+    const keyEvent = {
+      key: 'a',
+      preventDefault() {
+        defaultPrevented = true
+      },
+    }
+    keystrokes.press(keyEvent)
+    keystrokes.release(keyEvent)
+    await wait()
+
+    expect(defaultPrevented).toEqual(true)
     expect(w.get('div').text()).toEqual('isNotPressed')
   })
 })

--- a/packages/vue-keystrokes/src/use-key.ts
+++ b/packages/vue-keystrokes/src/use-key.ts
@@ -1,13 +1,24 @@
-import { getGlobalKeystrokes } from '@rwh/keystrokes'
+import {
+  BrowserKeyEventProps,
+  getGlobalKeystrokes,
+  Handler,
+  KeyEvent,
+} from '@rwh/keystrokes'
 import { ref, onMounted, onUnmounted, inject } from 'vue'
 import { keystrokesSymbol } from './use-keystrokes'
 
-export function useKey(key: string) {
+export function useKey(key: string, preventDefault?: boolean) {
   const keystrokes = inject(keystrokesSymbol, () => getGlobalKeystrokes(), true)
   const isPressed = ref(false)
 
-  const handler = {
-    onPressed: () => (isPressed.value = true),
+  const handler: Handler<KeyEvent<KeyboardEvent, BrowserKeyEventProps>> = {
+    onPressed: (e: KeyEvent<KeyboardEvent, BrowserKeyEventProps>) => {
+      isPressed.value = true
+      if (e.preventDefault && preventDefault === true) {
+        e.preventDefault()
+      }
+    },
+
     onReleased: () => (isPressed.value = false),
   }
 


### PR DESCRIPTION
So as not to break the API I opted to make preventDefault an optional parameter on the useKey and useKeyCombo hooks (React) / composables (Vue)

test: added tests for the preventDefault option in useKey/useKeyCombo for React and Vue
fix: useKeyCombo Vue composable was not unbinding key combos correctly


Vue Language Server was being painfully picky about the typings in useKeyCombo so I had to extract the generic type from the keystrokes instance... someone who knows more Typescript than me likely has a nicer way to handle this.