### PR TITLE
Only fire the longest matching sequence when combos overlap

### DIFF
--- a/packages/keystrokes/src/key-combo-state.ts
+++ b/packages/keystrokes/src/key-combo-state.ts
@@ -129,6 +129,10 @@ export class KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps> {
     return this._sequenceIndex
   }
 
+  get sequenceLength() {
+    return this._parsedKeyCombo.length;
+  }
+
   private _normalizedKeyCombo: string
   private _parsedKeyCombo: string[][][]
   private _handlerState: HandlerState<

--- a/packages/keystrokes/src/keystrokes.ts
+++ b/packages/keystrokes/src/keystrokes.ts
@@ -99,6 +99,11 @@ export class Keystrokes<
     KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps>
   >
 
+  private _keyCombosPressedByKey: Map<
+    string,
+    KeyComboState<OriginalEvent, KeyEventProps, KeyComboEventProps>[]
+  >
+
   constructor(
     options: KeystrokesOptions<
       OriginalEvent,
@@ -125,6 +130,7 @@ export class Keystrokes<
     this._activeKeyMap = new Map()
 
     this._watchedKeyComboStates = {}
+    this._keyCombosPressedByKey = new Map()
 
     this.bindEnvironment(options)
   }
@@ -357,8 +363,31 @@ export class Keystrokes<
 
     this._updateKeyComboStates()
 
-    for (const keyComboState of this._keyComboStatesArray)
-      keyComboState.executePressed(event)
+    const pressedCombos = this._keyComboStatesArray.filter(
+      (combo) => combo.isPressed,
+    )
+
+    if (pressedCombos.length > 0) {
+      const maxSequenceLength = Math.max(
+        ...pressedCombos.map((combo) => combo.sequenceLength),
+      )
+
+      const activatedCombos: KeyComboState<
+        OriginalEvent,
+        KeyEventProps,
+        KeyComboEventProps
+      >[] = []
+      for (const combo of pressedCombos) {
+        if (combo.sequenceLength === maxSequenceLength) {
+          combo.executePressed(event)
+          activatedCombos.push(combo)
+        }
+      }
+
+      if (activatedCombos.length > 0) {
+        this._keyCombosPressedByKey.set(event.key, activatedCombos)
+      }
+    }
   }
 
   private _handleKeyRelease(event: KeyEvent<OriginalEvent, KeyEventProps>) {
@@ -402,8 +431,13 @@ export class Keystrokes<
     this._tryReleaseSelfReleasingKeys()
     this._updateKeyComboStates()
 
-    for (const keyComboState of this._keyComboStatesArray)
-      keyComboState.executeReleased(event)
+    const activatedCombos = this._keyCombosPressedByKey.get(event.key)
+    if (activatedCombos) {
+      for (const combo of activatedCombos) {
+        combo.executeReleased(event)
+      }
+      this._keyCombosPressedByKey.delete(event.key)
+    }
   }
 
   private _updateKeyComboStates() {


### PR DESCRIPTION
Hej! Thanks for the great library — Up until now, we've been using keyboardjs, but now we're migrating to Keystrokes in our project [WEBKNOSSOS](https://webknossos.org/). Keystrokes is more feature-rich, but we still ran into a behavior issue we'd love to contribute a fix for.

### The problem
When a multi-stroke combo and a single-key combo share the same final key, both handlers fire simultaneously. For example, if you have:


bindKeyCombo('ctrl > k, m', () => console.log('long sequence activated'))
bindKeyCombo('m',           () => console.log('short sequence activated))
Pressing Ctrl+K then M triggers both handlers. From our point of view, in almost every real-world use case, if the user consciously pressed a prefix chord first, they clearly intend the longer sequence — the shorter one firing is more of an unintended side effect in our opinion.

### The fix
After _updateKeyComboStates() resolves which combos are now pressed, we find the maximum sequence length among all currently-pressed combos and only call executePressed on those with the longest sequence. Shorter overlapping combos are silently skipped for that key event.

To make sure release events stay consistent, we track which combos were actually activated per key in a _keyCombosPressedByKey map, and only fire executeReleased on those same combos when the key is lifted.

### Changes
- KeyComboState: adds a sequenceLength getter (exposes _parsedKeyCombo.length) so Keystrokes can compare sequence lengths without reaching into private state
- Keystrokes._handleKeyPress: filters pressed combos to only those with the maximum sequence length before calling executePressed
- Keystrokes._handleKeyRelease: uses the new _keyCombosPressedByKey map to release only the combos that were actually activated

If only one combo matches (the common case), pressedCombos has a single entry, and everything flows exactly as before. 

If you believe the behavior change introduced by this update should be optional, I’d be happy to adjust the PR accordingly. For example, it could become an option passable to Keystrokes instances.
Of course, other suggestions are welcome as well :)